### PR TITLE
deps: update node-sass to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "1.8.0",
     "ng2-dragula": "1.1.10",
-    "node-sass": "3.8.0",
+    "node-sass": "3.11.1",
     "pegjs": "0.9.0",
     "pegjs-loader": "0.4.0",
     "phantomjs-polyfill": "0.0.2",


### PR DESCRIPTION
This patch just updates the node-sass dependency in order for dilia to support node 7 (which has been pushed in Archlinux repositories at least). Even if node 7 is not (and should not) be the default version of node supported by dilia, its effective support does not harm the project.